### PR TITLE
Minor log format improvement

### DIFF
--- a/java-logging-spring/src/test/resources/logback-test-receiver.xml
+++ b/java-logging-spring/src/test/resources/logback-test-receiver.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
-            <pattern>%d %level [%thread] %logger: %msg%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:%line: %msg%n</pattern>
         </encoder>
     </appender>
     <appender name="TEST_APPENDER" class="uk.gov.hmcts.reform.logging.spring.TestAppender"/>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="TEST_APPENDER"/>
     </root>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="${LOGBACK_CONFIGURATION_DEBUG:-false}">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d %level [%thread] %logger: %msg%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{10}:%line: %msg%n</pattern>
         </encoder>
     </appender>
     <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Notes:
- [ ] Accumulated multi-project coverage report uploaded to Codacy
- [ ] Travis only runs against master and feature branches
- [ ] Request log message improvement:
  - removed arbitrary markers containing request uri, time the response took. Giving this information in the message
  - leaving request method and response code. I doubt method is needed
- [x] Log format slightly adjusted:
  - adding date format
  - adding log level spacing
  - reducing namespace clog
  - adding line number