### PR TITLE
Improving logging message, coverage

### DIFF
--- a/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptorTest.java
+++ b/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptorTest.java
@@ -7,6 +7,7 @@ import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
+import org.assertj.core.data.Index;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +19,7 @@ import java.util.Map;
 import static ch.qos.logback.classic.Level.INFO;
 import static net.logstash.logback.marker.Markers.appendEntries;
 import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 public class OutboundRequestLoggingInterceptorTest {
@@ -54,5 +56,22 @@ public class OutboundRequestLoggingInterceptorTest {
         fields.put("responseTime", 20L);
         fields.put("responseCode", 200);
         testAppender.assertEvent(1, INFO, "Outbound request finish", appendEntries(fields));
+    }
+
+    @Test
+    public void allowEmptyConstructorToBuildDefaultClock() throws Exception {
+        testAppender.clearEvents();
+
+        HttpContext context = new BasicHttpContext();
+        context.setAttribute(HTTP_TARGET_HOST, "http://www.google.com");
+
+        OutboundRequestLoggingInterceptor interceptor = new OutboundRequestLoggingInterceptor();
+
+        interceptor.process(new BasicHttpRequest("GET", "/something"), context);
+        interceptor.process(new BasicHttpResponse(new BasicStatusLine(ANY_PROTOCOL, 200, "any")), context);
+
+        assertThat(testAppender.getEvents()).extracting("message")
+            .contains("Outbound request start", Index.atIndex(0))
+            .contains("Outbound request finish", Index.atIndex(1));
     }
 }

--- a/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/TestAppender.java
+++ b/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/TestAppender.java
@@ -31,4 +31,12 @@ class TestAppender extends AppenderBase<ILoggingEvent> {
     public ILoggingEvent event(int index) {
         return events.get(index);
     }
+
+    public void clearEvents() {
+        events.clear();
+    }
+
+    public List<ILoggingEvent> getEvents() {
+        return events;
+    }
 }

--- a/java-logging-spring/build.gradle
+++ b/java-logging-spring/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: versions.spring
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.spring
   testCompile group: 'org.springframework.security', name: 'spring-security-test', version: '4.2.3.RELEASE'
+  testCompile group: 'com.google.code.tempus-fugit', name: 'tempus-fugit', version: '1.1'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.logging.filters;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.logging.HttpHeaders;
 import uk.gov.hmcts.reform.logging.MdcFields;
 
@@ -16,6 +18,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 public class RequestIdsSettingFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestIdsSettingFilter.class);
+
     private final Supplier<String> requestIdGenerator;
 
     public RequestIdsSettingFilter() {
@@ -64,5 +69,6 @@ public class RequestIdsSettingFilter implements Filter {
      */
     @Override
     public void destroy() {
+        LOG.debug("Settings logging destroyed due to timeout or filter exit");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
@@ -69,13 +69,14 @@ public class RequestStatusLoggingFilter implements Filter {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String requestMethod = httpServletRequest.getMethod();
         String requestUri = httpServletRequest.getRequestURI();
-        String status = isSuccess ? "processed" : "failed";
         long responseTime = clock.millis() - startTime;
 
         // collect markers
         Map<String, Object> fields = new HashMap<>();
 
         fields.put("requestMethod", requestMethod);
+        fields.put("requestUri", requestUri);
+        fields.put("responseTime", responseTime);
 
         if (response != null) {
             fields.put("responseCode", ((HttpServletResponse) response).getStatus());
@@ -84,6 +85,7 @@ public class RequestStatusLoggingFilter implements Filter {
         LogstashMarker marker = appendEntries(fields);
 
         // format the message
+        String status = isSuccess ? "processed" : "failed";
         String message = String.format("Request %s %s %s in %dms", requestMethod, requestUri, status, responseTime);
 
         // log the event

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
@@ -87,5 +87,6 @@ public class RequestStatusLoggingFilter implements Filter {
      */
     @Override
     public void destroy() {
+        LOG.debug("Status logging destroyed due to timeout or filter exit");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilterTest.java
@@ -56,11 +56,9 @@ public class RequestStatusLoggingFilterTest {
 
         Map<String, Object> fields = new HashMap<>();
         fields.put("requestMethod", "GET");
-        fields.put("requestURI", "/some/path");
-        fields.put("responseTime", 0L);
         fields.put("responseCode", 400);
 
-        testAppender.assertEvent(0, INFO, "Request processed", appendEntries(fields));
+        testAppender.assertEvent(0, INFO, "Request GET /some/path processed in 0ms", appendEntries(fields));
     }
 
     @Test
@@ -75,10 +73,8 @@ public class RequestStatusLoggingFilterTest {
 
         Map<String, Object> fields = new HashMap<>();
         fields.put("requestMethod", "GET");
-        fields.put("requestURI", "/some/path");
-        fields.put("responseTime", 0L);
 
-        testAppender.assertEvent(0, ERROR, "Request failed", appendEntries(fields));
+        testAppender.assertEvent(0, ERROR, "Request GET /some/path failed in 0ms", appendEntries(fields));
     }
 
     private HttpServletRequest requestWithMethodAndUri(String method, String url) {

--- a/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilterTest.java
@@ -56,6 +56,8 @@ public class RequestStatusLoggingFilterTest {
 
         Map<String, Object> fields = new HashMap<>();
         fields.put("requestMethod", "GET");
+        fields.put("requestUri", "/some/path");
+        fields.put("responseTime", 0L);
         fields.put("responseCode", 400);
 
         testAppender.assertEvent(0, INFO, "Request GET /some/path processed in 0ms", appendEntries(fields));
@@ -73,6 +75,8 @@ public class RequestStatusLoggingFilterTest {
 
         Map<String, Object> fields = new HashMap<>();
         fields.put("requestMethod", "GET");
+        fields.put("requestUri", "/some/path");
+        fields.put("responseTime", 0L);
 
         testAppender.assertEvent(0, ERROR, "Request GET /some/path failed in 0ms", appendEntries(fields));
     }


### PR DESCRIPTION
Notes:
- [ ] Accumulated multi-project coverage report uploaded to Codacy
- [ ] Travis only runs against master and feature branches
- [x] Request log message improvement:
  - removed arbitrary markers containing request uri, time the response took. Giving this information in the message
  - leaving request method and response code. I doubt method is needed
- [x] Log format slightly adjusted:
  - adding date format
  - adding log level spacing
  - reducing namespace clog
  - adding line number