### PR TITLE
Optionally allow logging Ps and error codes for all levels

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/logging/exception/AbstractLoggingException.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/exception/AbstractLoggingException.java
@@ -48,18 +48,24 @@ public abstract class AbstractLoggingException extends RuntimeException {
     }
 
     public static AbstractLoggingException getFromLogEvent(ILoggingEvent event) {
-        Throwable eventException = ((ThrowableProxy) event.getThrowableProxy()).getThrowable();
+        ThrowableProxy proxy = (ThrowableProxy) event.getThrowableProxy();
 
-        if (eventException instanceof AbstractLoggingException) {
-            return (AbstractLoggingException) eventException;
-        } else if (eventException.getCause() instanceof AbstractLoggingException) {
-            // for spring boot projects there's a generic exception wrapper
-            // let's try to cast the cause instead
-            return (AbstractLoggingException) eventException.getCause();
-        } else {
-            triggerBadImplementationLog(eventException);
+        if (proxy != null) {
+            Throwable eventException = ((ThrowableProxy) event.getThrowableProxy()).getThrowable();
 
-            return null;
+            if (eventException instanceof AbstractLoggingException) {
+                return (AbstractLoggingException) eventException;
+            } else if (eventException.getCause() instanceof AbstractLoggingException) {
+                // for spring boot projects there's a generic exception wrapper
+                // let's try to cast the cause instead
+                return (AbstractLoggingException) eventException.getCause();
+            } else {
+                triggerBadImplementationLog(eventException);
+
+                return null;
+            }
         }
+
+        return null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayout.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayout.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.logging.layout;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LayoutBase;
@@ -67,8 +66,8 @@ public class ReformLoggingLayout extends LayoutBase<ILoggingEvent> {
 
         log.append(String.format(" %s:%d: ", event.getLoggerName(), lineNumber));
 
-        if (event.getLevel().isGreaterOrEqual(Level.ERROR)) {
-            appendExtraExceptionFlags(log, event);
+        if (requireAlertLevel || requireErrorCode) {
+            appendExtraExceptionFlags(log, AbstractLoggingException.getFromLogEvent(event));
         }
 
         log.append(event.getFormattedMessage());
@@ -77,17 +76,13 @@ public class ReformLoggingLayout extends LayoutBase<ILoggingEvent> {
         return log.toString();
     }
 
-    private void appendExtraExceptionFlags(StringBuilder log, ILoggingEvent event) {
-        if (requireAlertLevel || requireErrorCode) {
-            AbstractLoggingException exception = AbstractLoggingException.getFromLogEvent(event);
+    private void appendExtraExceptionFlags(StringBuilder log, AbstractLoggingException exception) {
+        if (exception != null && requireAlertLevel) {
+            log.append(String.format("[%s] ", exception.getAlertLevel().name()));
+        }
 
-            if (exception != null && requireAlertLevel) {
-                log.append(String.format("[%s] ", exception.getAlertLevel().name()));
-            }
-
-            if (exception != null && requireErrorCode) {
-                log.append(String.format("%s. ", exception.getErrorCode()));
-            }
+        if (exception != null && requireErrorCode) {
+            log.append(String.format("%s. ", exception.getErrorCode()));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/logging/provider/AlertLevelJsonProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/provider/AlertLevelJsonProvider.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.logging.provider;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
 import net.logstash.logback.composite.AbstractFieldJsonProvider;
@@ -21,7 +20,7 @@ public class AlertLevelJsonProvider extends AbstractFieldJsonProvider<ILoggingEv
 
     @Override
     public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
-        if (requireAlertLevel && event.getLevel().isGreaterOrEqual(Level.ERROR)) {
+        if (requireAlertLevel) {
             AbstractLoggingException exception = AbstractLoggingException.getFromLogEvent(event);
 
             if (exception != null) {

--- a/src/main/java/uk/gov/hmcts/reform/logging/provider/ErrorCodeJsonProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/provider/ErrorCodeJsonProvider.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.logging.provider;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
 import net.logstash.logback.composite.AbstractFieldJsonProvider;
@@ -21,7 +20,7 @@ public class ErrorCodeJsonProvider extends AbstractFieldJsonProvider<ILoggingEve
 
     @Override
     public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
-        if (requireErrorCode && event.getLevel().isGreaterOrEqual(Level.ERROR)) {
+        if (requireErrorCode) {
             AbstractLoggingException exception = AbstractLoggingException.getFromLogEvent(event);
 
             if (exception != null) {

--- a/src/test/java/uk/gov/hmcts/reform/logging/AbstractLoggingTestSuite.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/AbstractLoggingTestSuite.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import org.junit.After;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+public class AbstractLoggingTestSuite {
+
+    protected ByteArrayOutputStream baos = null;
+
+    private PrintStream old = System.out;
+
+    protected class ProviderException extends AbstractLoggingException {
+        public ProviderException(String message) {
+            super(AlertLevel.P1, "0", message);
+        }
+    }
+
+    protected void captureOutput(String resource) throws IOException, JoranException {
+        System.setProperty("ROOT_APPENDER", "JSON_CONSOLE");
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.reset();
+        JoranConfigurator configurator = new JoranConfigurator();
+
+        InputStream configStream = getClass().getClassLoader().getResourceAsStream(resource);
+        configurator.setContext(loggerContext);
+        configurator.doConfigure(configStream);
+        configStream.close();
+
+        baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        System.setOut(ps);
+    }
+
+    @After
+    public void resetConsole() {
+        System.clearProperty("ROOT_APPENDER");
+        System.out.flush();
+        System.setOut(old);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
@@ -159,4 +159,24 @@ public class ReformLoggingLayoutTest {
             timestamp + " ERROR " + logger + ":\\d+: \\[P3\\] message\n"
         );
     }
+
+    @Test
+    public void testOutputForOptionalErrorValues() throws JoranException, IOException {
+        configLogback(LOGBACK_WITH_CUSTOM_DATE_FORMAT);
+
+        log.info("message");
+        log.info("message", new DummyP3Exception("ping not allowed"));
+
+        String timestamp = "\\d{2}-\\d{2}-\\d{4}";
+        String logger = this.getClass().getCanonicalName();
+
+        String output = baos.toString();
+
+        assertThat(output).containsPattern(
+            timestamp + " INFO  " + logger + ":\\d+: message\n"
+        );
+        assertThat(output).containsPattern(
+            timestamp + " INFO  " + logger + ":\\d+: \\[P3\\] 0. message\n"
+        );
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/logging/provider/ErrorCodeJsonProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/provider/ErrorCodeJsonProviderTest.java
@@ -8,13 +8,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.logging.AbstractLoggingTestSuite;
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AlertLevelJsonProviderTest extends AbstractLoggingTestSuite {
+public class ErrorCodeJsonProviderTest extends AbstractLoggingTestSuite {
 
     @Before
     public void setUp() throws IOException, JoranException {
@@ -27,14 +26,14 @@ public class AlertLevelJsonProviderTest extends AbstractLoggingTestSuite {
     public void testAlertLevel() throws IOException {
         assertThat(System.getProperty("ROOT_APPENDER")).isEqualTo("JSON_CONSOLE");
 
-        Logger log = LoggerFactory.getLogger(AlertLevelJsonProviderTest.class);
+        Logger log = LoggerFactory.getLogger(ErrorCodeJsonProviderTest.class);
 
         log.error("test", new ProviderException("oh no"));
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(baos.toString());
 
-        assertThat(node.at("/alertLevel").asText()).isEqualTo(AlertLevel.P1.name());
+        assertThat(node.at("/errorCode").asText()).isEqualTo("0");
         assertThat(node.at("/message").asText()).isEqualTo("test");
     }
 }


### PR DESCRIPTION
[JIRA](https://tools.hmcts.net/jira/browse/RPE-16)

- alert level and error code can be appended regardless the log level
- missing unit test for error code for json provider

_Pending work_:
- parameterise `logback.xml` to allow flagging on/off the new fields
- update README to reflect the changes
- update unit tests to prove the concept