### PR TITLE
ROC-1105: Correctly set headers on inbound requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group 'uk.gov.hmcts.reform'
-  version '1.2.2'
+  version '1.3.0'
 
   apply plugin: 'java'
   apply plugin: 'java-library'

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -72,12 +72,11 @@
     <rule ref="rulesets/java/strings.xml" />
     <rule ref="rulesets/java/sunsecure.xml" />
     <rule ref="rulesets/java/typeresolution.xml" />
-    <rule ref="rulesets/java/unnecessary.xml" />
-    <rule ref="rulesets/java/unusedcode.xml" />
-    <rule ref="rulesets/java/typeresolution.xml"/>
     <rule ref="rulesets/java/typeresolution.xml/SignatureDeclareThrowsException">
         <properties>
             <property name="IgnoreJUnitCompletely" value="true"/>
         </properties>
     </rule>
+    <rule ref="rulesets/java/unnecessary.xml" />
+    <rule ref="rulesets/java/unusedcode.xml" />
 </ruleset>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -74,5 +74,10 @@
     <rule ref="rulesets/java/typeresolution.xml" />
     <rule ref="rulesets/java/unnecessary.xml" />
     <rule ref="rulesets/java/unusedcode.xml" />
-
+    <rule ref="rulesets/java/typeresolution.xml"/>
+    <rule ref="rulesets/java/typeresolution.xml/SignatureDeclareThrowsException">
+        <properties>
+            <property name="IgnoreJUnitCompletely" value="true"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptor.java
+++ b/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptor.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.reform.logging.httpcomponents;
 
-import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
 import uk.gov.hmcts.reform.logging.HttpHeaders;
 import uk.gov.hmcts.reform.logging.MdcFields;
-
-import java.io.IOException;
 
 public class OutboundRequestIdSettingInterceptor implements HttpRequestInterceptor {
 

--- a/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptor.java
+++ b/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptor.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 public class OutboundRequestIdSettingInterceptor implements HttpRequestInterceptor {
 
     @Override
-    public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+    public void process(HttpRequest request, HttpContext context) {
         request.setHeader(HttpHeaders.ROOT_REQUEST_ID, MdcFields.getRootRequestId());
         request.setHeader(HttpHeaders.ORIGIN_REQUEST_ID, MdcFields.getRequestId());
     }

--- a/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptor.java
+++ b/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptor.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.logging.httpcomponents;
 
-import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
@@ -10,7 +9,6 @@ import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +31,7 @@ public class OutboundRequestLoggingInterceptor implements HttpRequestInterceptor
     }
 
     @Override
-    public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+    public void process(HttpRequest request, HttpContext context) {
         RequestLine requestLine = request.getRequestLine();
 
         context.setAttribute("startedOn", clock.millis());
@@ -44,7 +42,7 @@ public class OutboundRequestLoggingInterceptor implements HttpRequestInterceptor
     }
 
     @Override
-    public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
+    public void process(HttpResponse response, HttpContext context) {
         LOG.info(appendEntries(responseMarkers(context, response)), "Outbound request finish");
     }
 

--- a/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptorTest.java
+++ b/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestIdSettingInterceptorTest.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.logging.httpcomponents;
 
-import org.apache.http.HttpException;
 import org.apache.http.message.BasicHttpRequest;
 import org.junit.Test;
 import uk.gov.hmcts.reform.logging.HttpHeaders;
 import uk.gov.hmcts.reform.logging.MdcFields;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,7 +14,7 @@ public class OutboundRequestIdSettingInterceptorTest {
     private static final String ANY = "any";
 
     @Test
-    public void rootRequestIdShouldBeSet() throws IOException, HttpException {
+    public void rootRequestIdShouldBeSet() {
         MdcFields.setRootRequestId("ROOT_REQUEST_ID");
 
         BasicHttpRequest request = new BasicHttpRequest(ANY, ANY);
@@ -28,7 +25,7 @@ public class OutboundRequestIdSettingInterceptorTest {
     }
 
     @Test
-    public void originRequestIdShouldBeSet() throws IOException, HttpException {
+    public void originRequestIdShouldBeSet() {
         MdcFields.setRequestId("CURRENT_REQUEST_ID");
 
         BasicHttpRequest request = new BasicHttpRequest(ANY, ANY);

--- a/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptorTest.java
+++ b/java-logging-httpcomponents/src/test/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptorTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.logging.httpcomponents;
 
 import ch.qos.logback.classic.Logger;
-import org.apache.http.HttpException;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.message.BasicHttpResponse;
@@ -14,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -41,7 +39,7 @@ public class OutboundRequestLoggingInterceptorTest {
     }
 
     @Test
-    public void logsRequestAndResponseFields() throws IOException, HttpException {
+    public void logsRequestAndResponseFields() {
         HttpContext context = new BasicHttpContext();
         context.setAttribute(HTTP_TARGET_HOST, "http://www.google.com");
 
@@ -61,7 +59,7 @@ public class OutboundRequestLoggingInterceptorTest {
     }
 
     @Test
-    public void allowEmptyConstructorToBuildDefaultClock() throws IOException, HttpException {
+    public void allowEmptyConstructorToBuildDefaultClock() {
         testAppender.clearEvents();
 
         HttpContext context = new BasicHttpContext();

--- a/src/main/java/uk/gov/hmcts/reform/logging/HttpHeaders.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/HttpHeaders.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.logging;
 
 public final class HttpHeaders {
+    public static final String REQUEST_ID = "Request-Id";
     public static final String ROOT_REQUEST_ID = "Root-Request-Id";
     public static final String ORIGIN_REQUEST_ID = "Origin-Request-Id";
 
     private HttpHeaders() {
+        // Constants class
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
@@ -43,20 +43,28 @@ public class RequestIdsSettingFilter implements Filter {
      * {@inheritDoc}.
      */
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-        throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         try {
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-            String rootRequestId = httpServletRequest.getHeader(HttpHeaders.ROOT_REQUEST_ID);
-
             MdcFields.setSessionId(getSessionId(httpServletRequest));
-            MdcFields.setRequestId(requestIdGenerator.get());
-            MdcFields.setRootRequestId(rootRequestId == null ? MdcFields.getRequestId() : rootRequestId);
-            MdcFields.setOriginRequestId(httpServletRequest.getHeader(HttpHeaders.ORIGIN_REQUEST_ID));
+            setRequestTracingHeaders(httpServletRequest);
 
             chain.doFilter(request, response);
         } finally {
             MdcFields.removeAll();
+        }
+    }
+
+    private void setRequestTracingHeaders(HttpServletRequest httpServletRequest) {
+        String requestId = httpServletRequest.getHeader(HttpHeaders.REQUEST_ID);
+        if (isPresent(requestId)) {
+            MdcFields.setRequestId(requestId);
+            String rootRequestId = httpServletRequest.getHeader(HttpHeaders.ROOT_REQUEST_ID);
+            MdcFields.setRootRequestId(isPresent(rootRequestId) ? rootRequestId : requestId);
+            MdcFields.setOriginRequestId(httpServletRequest.getHeader(HttpHeaders.ORIGIN_REQUEST_ID));
+        } else {
+            MdcFields.setRequestId(requestIdGenerator.get());
+            MdcFields.setRootRequestId(MdcFields.getRequestId());
         }
     }
 
@@ -65,9 +73,10 @@ public class RequestIdsSettingFilter implements Filter {
         return session == null ? null : session.getId();
     }
 
-    /**
-     * {@inheritDoc}.
-     */
+    private boolean isPresent(String string) {
+        return string != null && !string.isEmpty();
+    }
+
     @Override
     public void destroy() {
         LOG.debug("Settings logging destroyed due to timeout or filter exit");

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
@@ -43,7 +43,11 @@ public class RequestIdsSettingFilter implements Filter {
      * {@inheritDoc}.
      */
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(
+        ServletRequest request,
+        ServletResponse response,
+        FilterChain chain
+    ) throws IOException, ServletException {
         try {
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
             MdcFields.setSessionId(getSessionId(httpServletRequest));

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilter.java
@@ -35,7 +35,8 @@ public class RequestIdsSettingFilter implements Filter {
      * {@inheritDoc}.
      */
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(FilterConfig filterConfig) {
+        // Nothing to do
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/filters/RequestStatusLoggingFilter.java
@@ -37,7 +37,7 @@ public class RequestStatusLoggingFilter implements Filter {
      * {@inheritDoc}.
      */
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(FilterConfig filterConfig) {
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilterTest.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.logging.filters;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.logging.HttpHeaders;
 import uk.gov.hmcts.reform.logging.MdcFields;
 
@@ -11,20 +14,23 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RequestIdsSettingFilterTest {
 
     private static final String GENERATED_REQUEST_ID = "some-generated-request-id";
     private static final ServletResponse ANY_RESPONSE = null;
 
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpSession httpSession;
+
     private final RequestIdsSettingFilter filter = new RequestIdsSettingFilter(() -> GENERATED_REQUEST_ID);
 
     @Test
     public void generateAndLogRequestId() throws IOException, ServletException {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
         filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
             assertThat(MdcFields.getRequestId()).isEqualTo(GENERATED_REQUEST_ID);
         });
@@ -90,8 +96,6 @@ public class RequestIdsSettingFilterTest {
 
     @Test
     public void sessionIdShouldNotBeLoggedIfSessionDoesNotExist() throws IOException, ServletException {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
         filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
             assertThat(MdcFields.getSessionId()).isNull();
         });
@@ -100,22 +104,18 @@ public class RequestIdsSettingFilterTest {
     }
 
     private HttpServletRequest requestWithRootRequestId(String requestId) {
-        HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader(HttpHeaders.ROOT_REQUEST_ID)).thenReturn(requestId);
         return request;
     }
 
     private HttpServletRequest requestWithOriginRequestId(String requestId) {
-        HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader(HttpHeaders.ORIGIN_REQUEST_ID)).thenReturn(requestId);
         return request;
     }
 
     private HttpServletRequest requestWithSessionId(String sessionId) {
-        HttpSession httpSession = mock(HttpSession.class);
         when(httpSession.getId()).thenReturn(sessionId);
 
-        HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getSession(false)).thenReturn(httpSession);
         return request;
     }

--- a/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/filters/RequestIdsSettingFilterTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.logging.filters;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -20,7 +21,9 @@ import static org.mockito.Mockito.when;
 public class RequestIdsSettingFilterTest {
 
     private static final String GENERATED_REQUEST_ID = "some-generated-request-id";
-    private static final ServletResponse ANY_RESPONSE = null;
+
+    @Mock
+    private ServletResponse response;
 
     @Mock
     private HttpServletRequest request;
@@ -29,65 +32,64 @@ public class RequestIdsSettingFilterTest {
 
     private final RequestIdsSettingFilter filter = new RequestIdsSettingFilter(() -> GENERATED_REQUEST_ID);
 
+    @Before
+    public void beforeEach() {
+        MdcFields.removeAll();
+    }
+
     @Test
-    public void generateAndLogRequestId() throws IOException, ServletException {
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
+    public void allRequestHeadersShouldBeReusedIfRequestIdHeaderIsProvided() throws Exception {
+        HttpServletRequest request = requestWithHeaders("id", "originId", "rootId");
+        filter.doFilter(request, response, (req, resp) -> {
+            assertThat(MdcFields.getRequestId()).isEqualTo("id");
+            assertThat(MdcFields.getOriginRequestId()).isEqualTo("originId");
+            assertThat(MdcFields.getRootRequestId()).isEqualTo("rootId");
+        });
+    }
+
+    @Test
+    public void originIdShouldNotBeSetWhenItsBlankAndRequestIdIsPresent() throws Exception {
+        HttpServletRequest request = requestWithHeaders("id", null, null);
+        filter.doFilter(request, response, (req, resp) -> {
+            assertThat(MdcFields.getRequestId()).isEqualTo("id");
+            assertThat(MdcFields.getOriginRequestId()).isNullOrEmpty();
+        });
+    }
+
+    @Test
+    public void rootIdShouldBeSetToRequestIdWhenItsBlankAndRequestIdIsPresent() throws Exception {
+        HttpServletRequest request = requestWithHeaders("id", null, null);
+        filter.doFilter(request, response, (req, resp) -> {
+            assertThat(MdcFields.getRequestId()).isEqualTo("id");
+            assertThat(MdcFields.getRootRequestId()).isEqualTo(MdcFields.getRequestId());
+        });
+    }
+
+    @Test
+    public void requestAndRootRequestIdsShouldBeSetWhenRequestIdIsNull() throws Exception {
+        HttpServletRequest request = requestWithHeaders(null, null, null);
+        filter.doFilter(request, response, (req, resp) -> {
             assertThat(MdcFields.getRequestId()).isEqualTo(GENERATED_REQUEST_ID);
+            assertThat(MdcFields.getRootRequestId()).isEqualTo(MdcFields.getRequestId());
+            assertThat(MdcFields.getOriginRequestId()).isNullOrEmpty();
         });
-
-        assertThat(MdcFields.getRequestId()).isNull();
     }
 
     @Test
-    public void rootRequestIdShouldBeReusedIfHeaderPresent() throws IOException, ServletException {
-        HttpServletRequest request = requestWithRootRequestId("root-request-id");
-
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
-            assertThat(MdcFields.getRootRequestId()).isEqualTo("root-request-id");
-        });
-
-        assertThat(MdcFields.getRootRequestId()).isNull();
-    }
-
-    @Test
-    public void rootRequestIdShouldBeGeneratedIfHeaderNotPresent() throws IOException, ServletException {
-        HttpServletRequest request = requestWithRootRequestId(null);
-
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
+    public void requestAndRootRequestIdsShouldBeSetWhenRequestIdIsBlank() throws Exception {
+        HttpServletRequest request = requestWithHeaders("", null, null);
+        filter.doFilter(request, response, (req, resp) -> {
             assertThat(MdcFields.getRequestId()).isEqualTo(GENERATED_REQUEST_ID);
-            assertThat(MdcFields.getRootRequestId()).isEqualTo(GENERATED_REQUEST_ID);
+            assertThat(MdcFields.getRootRequestId()).isEqualTo(MdcFields.getRequestId());
+            assertThat(MdcFields.getOriginRequestId()).isNullOrEmpty();
         });
-
-        assertThat(MdcFields.getRootRequestId()).isNull();
-    }
-
-    @Test
-    public void originRequestIdShouldBeUsedIfHeaderPresent() throws IOException, ServletException {
-        HttpServletRequest request = requestWithOriginRequestId("origin-request-id");
-
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
-            assertThat(MdcFields.getOriginRequestId()).isEqualTo("origin-request-id");
-        });
-
-        assertThat(MdcFields.getOriginRequestId()).isNull();
-    }
-
-    @Test
-    public void originRequestIdShouldNotBeGeneratedIfHeaderNotPresent() throws IOException, ServletException {
-        HttpServletRequest request = requestWithOriginRequestId(null);
-
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
-            assertThat(MdcFields.getOriginRequestId()).isEqualTo(null);
-        });
-
-        assertThat(MdcFields.getOriginRequestId()).isNull();
     }
 
     @Test
     public void sessionIdShouldBeLoggedIfTheSessionExists() throws IOException, ServletException {
         HttpServletRequest request = requestWithSessionId("some-session-id");
 
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
+        filter.doFilter(request, response, (req, resp) -> {
             assertThat(MdcFields.getSessionId()).isEqualTo("some-session-id");
         });
 
@@ -96,20 +98,17 @@ public class RequestIdsSettingFilterTest {
 
     @Test
     public void sessionIdShouldNotBeLoggedIfSessionDoesNotExist() throws IOException, ServletException {
-        filter.doFilter(request, ANY_RESPONSE, (req, resp) -> {
+        filter.doFilter(request, response, (req, resp) -> {
             assertThat(MdcFields.getSessionId()).isNull();
         });
 
         assertThat(MdcFields.getSessionId()).isNull();
     }
 
-    private HttpServletRequest requestWithRootRequestId(String requestId) {
-        when(request.getHeader(HttpHeaders.ROOT_REQUEST_ID)).thenReturn(requestId);
-        return request;
-    }
-
-    private HttpServletRequest requestWithOriginRequestId(String requestId) {
-        when(request.getHeader(HttpHeaders.ORIGIN_REQUEST_ID)).thenReturn(requestId);
+    private HttpServletRequest requestWithHeaders(String requestId, String originRequestId, String rootRequestId) {
+        when(request.getHeader(HttpHeaders.REQUEST_ID)).thenReturn(requestId);
+        when(request.getHeader(HttpHeaders.ORIGIN_REQUEST_ID)).thenReturn(originRequestId);
+        when(request.getHeader(HttpHeaders.ROOT_REQUEST_ID)).thenReturn(rootRequestId);
         return request;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/logging/provider/AlertLevelJsonProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/provider/AlertLevelJsonProviderTest.java
@@ -19,7 +19,7 @@ public class AlertLevelJsonProviderTest extends AbstractLoggingTestSuite {
     private static final Logger log = LoggerFactory.getLogger(AlertLevelJsonProviderTest.class);
 
     @Before
-    public void setUp() throws IOException, JoranException {
+    public void setUp() {
         System.setProperty("ROOT_APPENDER", "JSON_CONSOLE");
     }
 


### PR DESCRIPTION
Correctly propagates headers received on inbound requests as defined in [Reform logging specification](https://tools.hmcts.net/confluence/display/RTA/Logging).