### PR TITLE
Remove build branches specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
   directories:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
-branches:
-  only:
-  - master
-  - /^feature\/[a-zA-Z0-9\-]+$/
 before_install:
 - sudo apt-get install jq
 - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest


### PR DESCRIPTION
Removing the build branch specification as it appears to block artifacts publishing on tags.