### PR TITLE
Ensure stacktrace is after the event log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group 'uk.gov.hmcts.reform'
-  version '1.4.1'
+  version '1.4.2'
 
   apply plugin: 'java'
   apply plugin: 'java-library'

--- a/src/main/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayout.java
+++ b/src/main/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayout.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.logging.layout;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LayoutBase;
 import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
@@ -10,6 +12,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 public class ReformLoggingLayout extends LayoutBase<ILoggingEvent> {
 
@@ -71,7 +75,19 @@ public class ReformLoggingLayout extends LayoutBase<ILoggingEvent> {
         log.append(event.getFormattedMessage()).append(CoreConstants.LINE_SEPARATOR);
 
         if (proxy != null) {
-            proxy.fullDump();
+            Stream<StackTraceElementProxy> trace = Arrays.stream(proxy.getStackTraceElementProxyArray());
+
+            trace.forEach(step -> {
+                String string = step.toString();
+
+                log.append(CoreConstants.TAB).append(string);
+
+                ThrowableProxyUtil.subjoinPackagingData(log, step);
+
+                log.append(CoreConstants.LINE_SEPARATOR);
+            });
+
+            trace.close();
         }
 
         return log.toString();

--- a/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
@@ -188,7 +188,7 @@ public class ReformLoggingLayoutTest {
     }
 
     @Test
-    public void testStacktraceExists() throws JoranException, IOException {
+    public void testStacktraceExistsAfterTheLogEntry() throws JoranException, IOException {
         configLogback(LOGBACK);
 
         String message = "test stacktrace";
@@ -196,13 +196,10 @@ public class ReformLoggingLayoutTest {
         log.error(message, new DummyP2Exception());
 
         String logger = this.getClass().getCanonicalName();
-        String output = baos.toString();
 
-        assertThat(output).containsPattern(
+        assertThat(baos.toString()).containsPattern(
             DEFAULT_DATE_FORMAT + ERROR + getThreadName() + logger + ":\\d+: \\[P2\\] 0. " + message + "\n"
-        );
-        assertThat(output).containsPattern(
-            "\tat " + logger + ".testStacktraceExists(.*" + this.getClass().getSimpleName() + ".java:\\d+.*)\n"
+                + "\tat " + logger + ".testStacktraceExists(.*" + this.getClass().getSimpleName() + ".java:\\d+.*)\n"
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/logging/layout/ReformLoggingLayoutTest.java
@@ -36,6 +36,10 @@ public class ReformLoggingLayoutTest {
         DummyP2Exception() {
             super(AlertLevel.P2, "0", "oh no");
         }
+
+        DummyP2Exception(Throwable cause) {
+            super(AlertLevel.P2, "0", "oh no", cause);
+        }
     }
 
     private class DummyP3Exception extends AbstractLoggingException {
@@ -100,7 +104,7 @@ public class ReformLoggingLayoutTest {
 
         String message = "test output with bad exception";
 
-        log.error(message, new InvalidClassException("oh no"));
+        log.error(message, new InvalidClassException("Class null is invalid"));
 
         String logger = AbstractLoggingException.class.getCanonicalName();
         String errorClass = InvalidClassException.class.getCanonicalName();
@@ -200,6 +204,12 @@ public class ReformLoggingLayoutTest {
         assertThat(baos.toString()).containsPattern(
             DEFAULT_DATE_FORMAT + ERROR + getThreadName() + logger + ":\\d+: \\[P2\\] 0. " + message + "\n"
                 + "\tat " + logger + ".testStacktraceExists(.*" + this.getClass().getSimpleName() + ".java:\\d+.*)\n"
+        );
+
+        log.error(message, new DummyP2Exception(new ArithmeticException("There is no such operation ':'")));
+
+        assertThat(baos.toString()).containsPattern(
+            "Caused by: " + ArithmeticException.class.getCanonicalName() + ": There is no such operation ':'\n"
         );
     }
 


### PR DESCRIPTION
`proxy.fullDump` prints out straight to `System.out` and we want to build the single log event as a whole