### PR TITLE
Suggest to remove agent which is only needed for request component

### DIFF
--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -120,6 +120,14 @@ spring:
     name: My Application Insights WebApp
 ```
 
+In case service does not need request component, it is recommended to exclude auto-injected library from the project dependencies:
+
+```groovy
+configurations {
+  runtime.exclude group: 'com.microsoft.azure', module: 'applicationinsights-agent'
+}
+```
+
 Telemetry component stands for TelemetryClient Bean configuration so all the application needs to implement is component as follows:
 
 ```java


### PR DESCRIPTION
Generally, don't want to add two libraries for the project. This is merely a recommendation to remove from dependencies - no harm if it stays in case request component is not used. The agent want be used either