### PR TITLE
Bug: Override appinsight agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-spring</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.6.0'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.6.1'
 ```
 
 #### java-logging-httpcomponents
@@ -56,13 +56,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-httpcomponents</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.6.0'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.6.1'
 ```
 
 **Please note:** You will also need to implement a class that configures an HTTP client with interceptors for outbound HTTP requests and responses. See https://github.com/hmcts/cmc-claim-store/blob/master/src/main/java/uk/gov/hmcts/cmc/claimstore/clients/RestClient.java#L98 for an example.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group 'uk.gov.hmcts.reform'
-  version '1.6.0'
+  version '1.6.1'
 
   apply plugin: 'java'
   apply plugin: 'java-library'

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -14,14 +14,14 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-appinsights</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '1.6.0'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '1.6.1'
 ```
 
 It will automatically include Request Name interceptor and Request Tracking Filter configurations into spring boot web application.

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -27,7 +27,6 @@ bintray {
   key = System.getenv('BINTRAY_KEY')
   publications = ['Insights', 'Azure']
   publish = true
-  override = true
   pkg {
     repo = 'hmcts-maven'
     name = 'java-logging-appinsights'

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -27,6 +27,7 @@ bintray {
   key = System.getenv('BINTRAY_KEY')
   publications = ['Insights', 'Azure']
   publish = true
+  override = true
   pkg {
     repo = 'hmcts-maven'
     name = 'java-logging-appinsights'

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -25,7 +25,7 @@ publishing {
 bintray {
   user = System.getenv('BINTRAY_USER')
   key = System.getenv('BINTRAY_KEY')
-  publications = ['Insights', 'Azure']
+  publications = ['Insights']
   publish = true
   pkg {
     repo = 'hmcts-maven'


### PR DESCRIPTION
```bash
Execution failed for task ':java-logging-appinsights:bintrayUpload'.
```
> Could not upload to 'https://api.bintray.com/content/hmcts/hmcts-maven/java-logging-appinsights/1.6.0/com/microsoft/azure/applicationinsights-agent/2.0.0-BETA/applicationinsights-agent-2.0.0-BETA.jar': HTTP/1.1 409 Conflict [message:Unable to upload files: An artifact with the path 'com/microsoft/azure/applicationinsights-agent/2.0.0-BETA/applicationinsights-agent-2.0.0-BETA.jar' already exists under another version]
