### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-spring</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.0.1'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.0.2'
 ```
 
 #### java-logging-httpcomponents
@@ -56,13 +56,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-httpcomponents</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '2.0.1'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '2.0.2'
 ```
 
 **Please note:** You will also need to implement a class that configures an HTTP client with interceptors for outbound HTTP requests and responses. See https://github.com/hmcts/cmc-claim-store/blob/master/src/main/java/uk/gov/hmcts/cmc/claimstore/clients/RestClient.java#L98 for an example.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group 'uk.gov.hmcts.reform'
-  version '2.0.1'
+  version '2.0.2'
 
   apply plugin: 'java'
   apply plugin: 'java-library'

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -24,7 +24,7 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-appinsights</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '2.0.1'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '2.0.2'
 }
 ```
 


### PR DESCRIPTION
Changelog:

- Provide application version for app insights
- Require alert level / error code only for HMCTS loggers
- Provide exception helper class to avoid explicit set of error code