### PR TITLE
Feature: Synthetic source

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-spring</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.1.1'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.2.0'
 ```
 
 #### java-logging-httpcomponents
@@ -56,13 +56,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-httpcomponents</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '2.1.1'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '2.2.0'
 ```
 
 **Please note:** You will also need to implement a class that configures an HTTP client with interceptors for outbound HTTP requests and responses. See https://github.com/hmcts/cmc-claim-store/blob/master/src/main/java/uk/gov/hmcts/cmc/claimstore/clients/RestClient.java#L98 for an example.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-version=2.1.1
-
+version=2.2.0

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -78,16 +78,40 @@ For custom telemetry metrics implement `AbstractAppInsights` already provided wi
 
 #### Initialisers
 
+
+##### Context
+
 - DeviceInfoContextInitializer
 - SdkVersionContextInitializer
+
+##### Telemetry
+
 - SequencePropertyInitializer
 - TimestampPropertyInitializer
 - WebOperationIdTelemetryInitializer
 - WebOperationNameTelemetryInitializer
 - WebSessionTelemetryInitializer
+- WebSyntheticRequestTelemetryInitializer
 - WebUserTelemetryInitializer
 - WebUserAgentTelemetryInitializer
 - CloudRoleNameInitializer
+
+`WebSyntheticRequestTelemetryInitializer` provides functionality to separate out requests via so called Synthetic Source tag.
+Unfortunately, custom headers are package private.
+In order to use this feature add following headers at will:
+
+- When `SyntheticTest-Source` is present:
+  - `SyntheticTest-Source` as Source name
+  - `SyntheticTest-UserId`
+  - `SyntheticTest-SessionId`
+  - `SyntheticTest-OperationId`
+  - `SyntheticTest-TestName`
+  - `SyntheticTest-RunId`
+  - `SyntheticTest-Location`
+- Otherwise:
+  - `Application Insights Availability Monitoring` as Source name
+  - `SyntheticTest-RunId`
+  - `SyntheticTest-Location`
 
 #### Developer mode
 

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -24,7 +24,7 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-appinsights</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '2.1.1'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '2.2.0'
 }
 ```
 

--- a/java-logging-appinsights/src/main/resources/ApplicationInsights.xml
+++ b/java-logging-appinsights/src/main/resources/ApplicationInsights.xml
@@ -21,8 +21,11 @@
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer"/>
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSyntheticRequestTelemetryInitializer"/>
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer"/>
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer"/>
+
+        <!-- custom -->
         <Add type="uk.gov.hmcts.reform.logging.appinsights.telemetry.initializers.CloudRoleNameInitializer"/>
     </TelemetryInitializers>
 </ApplicationInsights>


### PR DESCRIPTION
Web telemetry initialiser for synthetic source purposefully designed for separation of tests/robots/actual/etc requests

Related Jira: [Exclude smoke test data from being included in App Insights reporting](https://tools.hmcts.net/jira/browse/RPE-336)