### PR TITLE
Refactored CloudRoleNameInitializer to implement TelemetryInitializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-spring</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '4.0.0'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '4.0.1'
 ```
 
 #### java-logging-httpcomponents
@@ -53,13 +53,13 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-httpcomponents</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '4.0.0'
+compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '4.0.1'
 ```
 
 **Please note:** You will also need to implement a class that configures an HTTP client with interceptors for outbound HTTP requests and responses. See https://github.com/hmcts/cmc-claim-store/blob/master/src/main/java/uk/gov/hmcts/cmc/claimstore/clients/RestClient.java#L98 for an example.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.0
+version=4.0.1

--- a/java-logging-appinsights/src/main/java/uk/gov/hmcts/reform/logging/appinsights/telemetry/initializers/CloudRoleNameInitializer.java
+++ b/java-logging-appinsights/src/main/java/uk/gov/hmcts/reform/logging/appinsights/telemetry/initializers/CloudRoleNameInitializer.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.reform.logging.appinsights.telemetry.initializers;
 
+import com.microsoft.applicationinsights.extensibility.TelemetryInitializer;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
-import com.microsoft.applicationinsights.web.extensibility.initializers.WebTelemetryInitializerBase;
 
-public class CloudRoleNameInitializer extends WebTelemetryInitializerBase {
+public class CloudRoleNameInitializer implements TelemetryInitializer {
+
     @Override
-    protected void onInitializeTelemetry(Telemetry telemetry) {
+    public void initialize(Telemetry telemetry) {
         if (SpringApplicationName.get() == null) {
             throw new IllegalStateException("spring.application.name configuration property is not set");
         } else {


### PR DESCRIPTION
Notes:
Current logging behaviour does not set Cloud Role Name on logback traces is does not have web context.
As CloudRoleNameInitializer is not applicable exclusively to web components make more sense if it implements directly from TelemetryInitializer.
This will fix logback log setting the cloud role name.