### PR TITLE
Features/appinsightsinstrumentationkey

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.0.0
+version=5.0.1

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -24,7 +24,7 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-appinsights</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '5.0.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '5.0.1'
 }
 ```
 
@@ -70,10 +70,9 @@ TelemetryClient can be `autowired`  to implement custom telemetry metrics.
 
 #### Provide Instrumentation Key
      
-Add below to your application properties to be compatible with current shared CNP configurations.
-
+Configure below spring property with App Insights Instrumentation key. While using CNP webapp module, this is taken care. 
 ```properties
-azure.application-insights.instrumentation-key=${APPINSIGHTS_INSTRUMENTATIONKEY}
+azure.application-insights.instrumentation-key=<key here>
 ```
 
 ### Configuration defaults

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -71,6 +71,7 @@ TelemetryClient can be `autowired`  to implement custom telemetry metrics.
 #### Provide Instrumentation Key
      
 Set the environment variable: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY. If you are deploying using the CNP pipeline this will be automatically added for you.
+You can also set it using a spring property (useful for tests):
 ```properties
 azure.application-insights.instrumentation-key=<key here>
 ```

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -70,7 +70,7 @@ TelemetryClient can be `autowired`  to implement custom telemetry metrics.
 
 #### Provide Instrumentation Key
      
-Set environment variable: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY, if you are deploying using the CNP pipeline this will be automatically added for you
+Set the environment variable: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY. If you are deploying using the CNP pipeline this will be automatically added for you.
 ```properties
 azure.application-insights.instrumentation-key=<key here>
 ```

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -71,11 +71,12 @@ TelemetryClient can be `autowired`  to implement custom telemetry metrics.
 #### Provide Instrumentation Key
      
 Set the environment variable: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY. If you are deploying using the CNP pipeline this will be automatically added for you.
+
 You can also set it using a spring property (useful for tests):
+
 ```properties
 azure.application-insights.instrumentation-key=<key here>
 ```
-
 ### Configuration defaults
 
 #### Modules configured by spring starter

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -70,7 +70,7 @@ TelemetryClient can be `autowired`  to implement custom telemetry metrics.
 
 #### Provide Instrumentation Key
      
-Configure below spring property with App Insights Instrumentation key. While using CNP webapp module, this is taken care. 
+Set environment variable: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY, if you are deploying using the CNP pipeline this will be automatically added for you
 ```properties
 azure.application-insights.instrumentation-key=<key here>
 ```

--- a/java-logging-appinsights/src/main/resources/Application.properties
+++ b/java-logging-appinsights/src/main/resources/Application.properties
@@ -1,1 +1,0 @@
-azure.application-insights.instrumentation-key=${APPINSIGHTS_INSTRUMENTATIONKEY}

--- a/java-logging-appinsights/src/test/java/uk/gov/hmcts/reform/logging/appinsights/AppInsightsAllComponentsTest.java
+++ b/java-logging-appinsights/src/test/java/uk/gov/hmcts/reform/logging/appinsights/AppInsightsAllComponentsTest.java
@@ -28,7 +28,7 @@ public class AppInsightsAllComponentsTest {
 
     @BeforeClass
     public static void setUp() {
-        variables.set("APPINSIGHTS_INSTRUMENTATIONKEY", "some-key");
+        variables.set("AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY", "some-key");
     }
 
     @Test


### PR DESCRIPTION
Changing instrumentation key spring property to default SDK property.
cnp-module-webapp module has been [modified](https://github.com/hmcts/cnp-module-webapp/pull/143) to pass this variable from resource attributes.
