### PR TITLE
Rename to logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ deploy:
   file_glob: true
   file:
   - build/libs/java-logging-*.jar
-  - java-logging-appinsights/build/libs/java-logging-appinsights-*.jar
-  - java-logging-httpcomponents/build/libs/java-logging-httpcomponents-*.jar
-  - java-logging-spring/build/libs/java-logging-spring-*.jar
+  - java-logging-appinsights/build/libs/logging-appinsights-*.jar
+  - java-logging-httpcomponents/build/libs/logging-httpcomponents-*.jar
+  - java-logging-spring/build/libs/logging-spring-*.jar
   skip_cleanup: true
   on:
     repo: hmcts/java-logging

--- a/README.md
+++ b/README.md
@@ -30,36 +30,19 @@ Use for automatic configuration of Azure Application Insights for a Spring Boot 
 
 Use for formatting log output in Spring Boot applications.
 
-Maven:
-```xml
-<dependency>
-    <groupId>uk.gov.hmcts.reform</groupId>
-    <artifactId>java-logging-spring</artifactId>
-    <version>4.0.1</version>
-</dependency>
-```
 
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '4.0.1'
+compile group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: '4.0.1'
 ```
 
 #### java-logging-httpcomponents
 
 Use for adding request IDs to external HTTP / HTTPS requests.
 
-Maven:
-```xml
-<dependency>
-    <groupId>uk.gov.hmcts.reform</groupId>
-    <artifactId>java-logging-httpcomponents</artifactId>
-    <version>4.0.1</version>
-</dependency>
-```
-
 Gradle:
 ```groovy
-compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '4.0.1'
+compile group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: '4.0.1'
 ```
 
 **Please note:** You will also need to implement a class that configures an HTTP client with interceptors for outbound HTTP requests and responses. See https://github.com/hmcts/cmc-claim-store/blob/master/src/main/java/uk/gov/hmcts/cmc/claimstore/clients/RestClient.java#L98 for an example.
@@ -87,15 +70,6 @@ By default the module will use a simple, human-friendly logging format which can
 ```
 
 Root logging level will be set to `INFO`. It can be adjusted by setting a `ROOT_LOGGING_LEVEL` environment variable.
-
-### Service details configuration
-
-As can be seen above the JSON format logs additional metadata information which is configurable via environment variables:
-- `REFORM_SERVICE_TYPE` which defaults to *java*,
-- `REFORM_SERVICE_NAME` which defaults to *undefined*,
-- `REFORM_TEAM` which defaults to *undefined*,
-- `REFORM_ENVIRONMENT` which defaults to *undefined*,
-- `HOSTNAME` which defaults to *undefined*, but in general should be set by the OS.
 
 ### Additional Logback configuration:
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ publishing {
       artifact sourcesJar
       artifact javadocJar
       groupId project.group
-      artifactId 'java-logging'
+      artifactId 'logging'
       version project.version
     }
   }
@@ -137,7 +137,7 @@ bintray {
   publish = true
   pkg {
     repo = 'hmcts-maven'
-    name = 'java-logging'
+    name = 'logging'
     userOrg = 'hmcts'
     licenses = ['MIT']
     vcsUrl = 'https://github.com/hmcts/java-logging'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.0-beta
+version=5.1.0-rc

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: '5.1.0-beta'
+  compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: '5.1.0-beta'
 }
 ```
 
@@ -104,7 +104,7 @@ azure.application-insights.instrumentation-key=<key here>
 - CloudInfoContextInitializer
 - SpringBootTelemetryInitializer
 
-#### Initializers configured by java-logging-appinsights
+#### Initializers configured by logging-appinsights
 
 ##### Context
 ContextInitializer ( Custom Initializer to set component version to context)

--- a/java-logging-appinsights/README.md
+++ b/java-logging-appinsights/README.md
@@ -24,7 +24,7 @@ Maven:
 <dependency>
     <groupId>uk.gov.hmcts.reform</groupId>
     <artifactId>java-logging-appinsights</artifactId>
-    <version>5.1.0-beta</version>
+    <version>5.1.0-rc</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: '5.1.0-beta'
+  compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: '5.1.0-rc'
 }
 ```
 

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -14,7 +14,7 @@ publishing {
       artifact sourcesJar
       artifact javadocJar
       groupId project.group
-      artifactId 'java-logging-appinsights'
+      artifactId 'logging-appinsights'
       version project.version
     }
   }
@@ -27,7 +27,7 @@ bintray {
   publish = true
   pkg {
     repo = 'hmcts-maven'
-    name = 'java-logging-appinsights'
+    name = 'logging-appinsights'
     userOrg = 'hmcts'
     licenses = ['MIT']
     vcsUrl = 'https://github.com/hmcts/java-logging'

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 def versions = [
   springBoot: '2.1.8.RELEASE',
-  appInsights: '2.5.0-BETA'
+  appInsights: '2.5.0-BETA.5'
 ]
 
 publishing {

--- a/java-logging-httpcomponents/build.gradle
+++ b/java-logging-httpcomponents/build.gradle
@@ -5,7 +5,7 @@ publishing {
       artifact sourcesJar
       artifact javadocJar
       groupId project.group
-      artifactId 'java-logging-httpcomponents'
+      artifactId 'logging-httpcomponents'
       version project.version
     }
   }
@@ -18,7 +18,7 @@ bintray {
   publish = true
   pkg {
     repo = 'hmcts-maven'
-    name = 'java-logging-httpcomponents'
+    name = 'logging-httpcomponents'
     userOrg = 'hmcts'
     licenses = ['MIT']
     vcsUrl = 'https://github.com/hmcts/java-logging'

--- a/java-logging-spring/build.gradle
+++ b/java-logging-spring/build.gradle
@@ -9,7 +9,7 @@ publishing {
       artifact sourcesJar
       artifact javadocJar
       groupId project.group
-      artifactId 'java-logging-spring'
+      artifactId 'logging-spring'
       version project.version
     }
   }
@@ -22,7 +22,7 @@ bintray {
   publish = true
   pkg {
     repo = 'hmcts-maven'
-    name = 'java-logging-spring'
+    name = 'logging-spring'
     userOrg = 'hmcts'
     licenses = ['MIT']
     vcsUrl = 'https://github.com/hmcts/java-logging'


### PR DESCRIPTION
There's no need for a java prefix, jcenter won't accept java-logging-appinsights because it used to publish a microsoft jar, I've been trying for 6 months to get
their support to fix it but they can't seem to.