### PR TITLE
avoid double logging

### DIFF
--- a/java-logging-appinsights/src/main/resources/logback-appinsights.xml
+++ b/java-logging-appinsights/src/main/resources/logback-appinsights.xml
@@ -7,7 +7,7 @@
         <appender-ref ref="APP_INSIGHTS" />
     </appender>
 
-    <logger name="uk.gov.hmcts" level="info">
+    <logger name="uk.gov.hmcts" level="info" additivity="false">
         <appender-ref ref="ASYNC_APP_INSIGHTS" />
     </logger>
 </included>


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* if there is an exception in 'uk.gov.hmcts' package it logs the errors twice
*
*
