### PR TITLE
Replace deprecated compile usages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,12 +68,12 @@ allprojects {
   }
 
   dependencies {
-    compile group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.4'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
-    compile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.30'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
-    testCompile group: 'junit', name: 'junit', version: '4.13'
+    implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.4'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
+    implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.30'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    api group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.13'
   }
 
   // before committing a change, make sure task still works
@@ -154,9 +154,9 @@ bintray {
 }
 
 dependencies {
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
-  testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
-  testCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
-  testCompile group: 'com.google.code.tempus-fugit', name: 'tempus-fugit', version: '1.1'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
+  testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+  testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
+  testImplementation group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+  testImplementation group: 'com.google.code.tempus-fugit', name: 'tempus-fugit', version: '1.1'
 }

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -55,8 +55,8 @@ dependencyManagement {
 dependencies {
   api group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
 
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: versions.appInsights
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: versions.appInsights
+  api group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: versions.appInsights
+  api group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: versions.appInsights
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/java-logging-appinsights/build.gradle
+++ b/java-logging-appinsights/build.gradle
@@ -53,13 +53,13 @@ dependencyManagement {
 }
 
 dependencies {
-  compileOnly group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
+  api group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
 
-  compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: versions.appInsights
-  compile group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: versions.appInsights
+  implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: versions.appInsights
+  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: versions.appInsights
 
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
 
-  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+  testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
 }

--- a/java-logging-httpcomponents/build.gradle
+++ b/java-logging-httpcomponents/build.gradle
@@ -32,11 +32,11 @@ bintray {
 }
 
 dependencies {
-  compile project(':')
-  compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
+  implementation project(':')
+  implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
 
-  testCompile project(':').sourceSets.test.output
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-  testCompile group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
-  testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+  testImplementation project(':').sourceSets.test.output
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
+  testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.16.1'
+  testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }

--- a/java-logging-spring/build.gradle
+++ b/java-logging-spring/build.gradle
@@ -46,15 +46,15 @@ dependencyManagement {
 }
 
 dependencies {
-  compile project(':')
-  compileOnly group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
+  implementation project(':')
+  api group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
 
-  testCompile project(':').sourceSets.test.output
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  testImplementation project(':').sourceSets.test.output
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
-  testCompile group: 'org.springframework.security', name: 'spring-security-test'
+  testImplementation group: 'org.springframework.security', name: 'spring-security-test'
 
-  testCompile group: 'com.google.code.tempus-fugit', name: 'tempus-fugit', version: '1.1'
+  testImplementation group: 'com.google.code.tempus-fugit', name: 'tempus-fugit', version: '1.1'
 }


### PR DESCRIPTION
Follow up #228: Use of compile DSL is deprecated