### PR TITLE
Add JitPack workflow to force build on new tag

### DIFF
--- a/.github/workflows/jitpack_build.yml
+++ b/.github/workflows/jitpack_build.yml
@@ -1,0 +1,39 @@
+name: Trigger JitPack Build
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Trigger Build in JitPack
+      run: |
+        echo "Triggering JitPack build"
+        
+        PACKAGES_URL="https://jitpack.io/com/github/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/tags/}/"
+        PACKAGES_FILE="packages.txt"
+        touch ${PACKAGES_FILE}
+        # Try the URL 3 times before failing
+        count=1
+        until [[ $count -gt 3 ]] || [[ $(cat ${PACKAGES_FILE} | wc -l | xargs ) -gt 1 ]] ; do
+          echo "Attempt ${count}/3"
+          STATUS=$(curl -s -o packages.txt -w "%{http_code}" --max-time 900 ${PACKAGES_URL})
+          
+          let count+=1
+          sleep 5
+        done
+        
+        echo "::group::Files Available"
+        echo $(cat ${PACKAGES_FILE})
+        echo "::endgroup::"
+        
+        if [[ $count -gt 3 ]]; then 
+          echo "FAILURE: ${STATUS} response from JitPack"
+          exit 1 
+        fi


### PR DESCRIPTION
- Force JitPack build when a new tag is created
